### PR TITLE
Change indicator color from white-black to white-transparent

### DIFF
--- a/stack.v1.js
+++ b/stack.v1.js
@@ -54,7 +54,7 @@ function stack() {
         .style("position", "absolute")
         .style("left", 0)
         .style("width", "3px")
-        .style("background", "linear-gradient(to top,black,white)");
+        .style("background", "linear-gradient(to top,rgba(255,255,255,0),white)");
 
     var sectionCurrent = d3.select(section[0][0]).style("display", "block"),
         sectionNext = d3.select(section[0][1]).style("display", "block");


### PR DESCRIPTION
Change indicator color from `white-black` to `white-transparent` just so that it looks less odd against a colored background. :star2: 

Before

![image](https://cloud.githubusercontent.com/assets/1153134/4021483/79c6b518-2af5-11e4-8a5b-d4880fa0c8c4.png)

After

![image](https://cloud.githubusercontent.com/assets/1153134/4021484/7fb8c95c-2af5-11e4-82e8-e3cb08f2b173.png)

Against a black background it'd be the same:

![image](https://cloud.githubusercontent.com/assets/1153134/4021493/d3b1aeac-2af5-11e4-9862-e504c132e174.png)
