### PR TITLE
Make the call to action a link

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ a:hover {
   <p>Stack is made by <a href="http://bost.ocks.org/mike/" rel="author">Mike Bostock</a>
     <br>and is available on <a href="https://github.com/mbostock/stack">GitHub</a>
     <br>under the <a href="https://github.com/mbostock/stack/blob/gh-pages/LICENSE">BSD license</a>.
-  <p class="grey">View source to get started.
+  <p><a style="color:#777;text-decoration:none;" href="https://github.com/mbostock/stack">View source to get started.</a>
 </section>
 
 <script src="d3.v3.min.js"></script>


### PR DESCRIPTION
The first time I scrolled through mbostock.github.io/stack I tried to click the call-to-action "View source to get started" text, then tried to click the word "source" in that text, only then did I go up to the GitHub link.
